### PR TITLE
Fix spurious filename-derived types in multi-file codegen

### DIFF
--- a/src/packages/nexus-rpc-gen-core/package.json
+++ b/src/packages/nexus-rpc-gen-core/package.json
@@ -32,5 +32,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2"
   }
 }

--- a/src/packages/nexus-rpc-gen-core/src/generator.ts
+++ b/src/packages/nexus-rpc-gen-core/src/generator.ts
@@ -85,6 +85,10 @@ export class Generator {
     const schemaInput = new JSONSchemaInput(new LocalFetchingSchemaStore());
     for (const schema of sources.sources) {
       const jsonSchema = {
+        // Set title to end with __ALL_TYPES__ so quicktype uses this name for the
+        // top-level entry even with multiple sources (otherwise it falls back
+        // to the filename, creating spurious types like "example.nexusrpc.yaml")
+        title: schema.sourceURI.toString() + "/__ALL_TYPES__",
         ...schema.sharedJsonSchema,
         ...schema.topLevelJsonSchemaTypes,
       };

--- a/src/packages/nexus-rpc-gen-core/tsconfig.json
+++ b/src/packages/nexus-rpc-gen-core/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["./src/**/*.ts"],
   "compilerOptions": {
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src"
   }

--- a/src/packages/nexus-rpc-gen-tests/languages/ts/src/services/kitchen-sink.ts
+++ b/src/packages/nexus-rpc-gen-tests/languages/ts/src/services/kitchen-sink.ts
@@ -11,26 +11,36 @@ export const kitchenSinkService = nexus.service("KitchenSinkService", {
   /**
    * Counts the characters in the string
    */
-  scalarArgScalarResult: nexus.operation<KitchenSinkServiceScalarArgScalarResultInput, KitchenSinkServiceScalarArgScalarResultOutput>(),
+  scalarArgScalarResult: nexus.operation<
+    KitchenSinkServiceScalarArgScalarResultInput,
+    KitchenSinkServiceScalarArgScalarResultOutput
+  >(),
 
   /**
    * Counts the characters in a string
    */
-  complexArgComplexResultInline: nexus.operation<KitchenSinkServiceComplexArgComplexResultInlineInput, KitchenSinkServiceComplexArgComplexResultInlineOutput>(),
+  complexArgComplexResultInline: nexus.operation<
+    KitchenSinkServiceComplexArgumentComplexResultInlineInput,
+    KitchenSinkServiceComplexArgumentComplexResultInlineOutput
+  >(),
 
   scalarArgScalarResultExternal: nexus.operation<ScalarInput, ScalarOutput>(),
 
-  complexArgComplexResultExternal: nexus.operation<ComplexInput, ComplexOutput>(),
+  complexArgComplexResultExternal: nexus.operation<
+    ComplexInput,
+    ComplexOutput
+  >(),
 });
 
 export const strangeItem = nexus.service("Strange{Item}", {
-  strangeItem: nexus.operation<StrangeItem, PurpleStrangeItem>({ name: "Strange{Item}" }),
+  strangeItem: nexus.operation<StrangeItem, PurpleStrangeItem>({
+    name: "Strange{Item}",
+  }),
 
   strangeItem2: nexus.operation<void, void>({ name: "StrangeItem" }),
 });
 
-export const strangeItem2 = nexus.service("StrangeItem", {
-});
+export const strangeItem2 = nexus.service("StrangeItem", {});
 
 export const reservedWordService = nexus.service("ReservedWordService", {
   toStringOperation: nexus.operation<void, void>({ name: "ToString" }),
@@ -69,7 +79,7 @@ export type ScalarOutput = number;
 /**
  * Input type
  */
-export interface KitchenSinkServiceComplexArgComplexResultInlineInput {
+export interface KitchenSinkServiceComplexArgumentComplexResultInlineInput {
   /**
    * String to count
    */
@@ -79,7 +89,7 @@ export interface KitchenSinkServiceComplexArgComplexResultInlineInput {
 /**
  * Output type
  */
-export interface KitchenSinkServiceComplexArgComplexResultInlineOutput {
+export interface KitchenSinkServiceComplexArgumentComplexResultInlineOutput {
   /**
    * Count of characters
    */
@@ -87,7 +97,7 @@ export interface KitchenSinkServiceComplexArgComplexResultInlineOutput {
 }
 
 export interface ComplexInput {
-  selfRef?:       ComplexInput;
+  selfRef?: ComplexInput;
   someSharedObj?: SharedObject;
 }
 
@@ -96,7 +106,7 @@ export interface SharedObject {
 }
 
 export interface ComplexOutput {
-  selfRef?:       ComplexOutput;
+  selfRef?: ComplexOutput;
   someSharedObj?: SharedObject;
 }
 
@@ -109,8 +119,8 @@ export interface PurpleStrangeItem {
 }
 
 export interface DateInput {
-  date?:     Date;
+  date?: Date;
   dateTime?: Date;
-  time?:     string;
+  time?: string;
   [property: string]: any;
 }

--- a/src/packages/nexus-rpc-gen-tests/languages/ts/src/services/kitchen-sink.ts
+++ b/src/packages/nexus-rpc-gen-tests/languages/ts/src/services/kitchen-sink.ts
@@ -11,36 +11,26 @@ export const kitchenSinkService = nexus.service("KitchenSinkService", {
   /**
    * Counts the characters in the string
    */
-  scalarArgScalarResult: nexus.operation<
-    KitchenSinkServiceScalarArgScalarResultInput,
-    KitchenSinkServiceScalarArgScalarResultOutput
-  >(),
+  scalarArgScalarResult: nexus.operation<KitchenSinkServiceScalarArgScalarResultInput, KitchenSinkServiceScalarArgScalarResultOutput>(),
 
   /**
    * Counts the characters in a string
    */
-  complexArgComplexResultInline: nexus.operation<
-    KitchenSinkServiceComplexArgumentComplexResultInlineInput,
-    KitchenSinkServiceComplexArgumentComplexResultInlineOutput
-  >(),
+  complexArgComplexResultInline: nexus.operation<KitchenSinkServiceComplexArgComplexResultInlineInput, KitchenSinkServiceComplexArgComplexResultInlineOutput>(),
 
   scalarArgScalarResultExternal: nexus.operation<ScalarInput, ScalarOutput>(),
 
-  complexArgComplexResultExternal: nexus.operation<
-    ComplexInput,
-    ComplexOutput
-  >(),
+  complexArgComplexResultExternal: nexus.operation<ComplexInput, ComplexOutput>(),
 });
 
 export const strangeItem = nexus.service("Strange{Item}", {
-  strangeItem: nexus.operation<StrangeItem, PurpleStrangeItem>({
-    name: "Strange{Item}",
-  }),
+  strangeItem: nexus.operation<StrangeItem, PurpleStrangeItem>({ name: "Strange{Item}" }),
 
   strangeItem2: nexus.operation<void, void>({ name: "StrangeItem" }),
 });
 
-export const strangeItem2 = nexus.service("StrangeItem", {});
+export const strangeItem2 = nexus.service("StrangeItem", {
+});
 
 export const reservedWordService = nexus.service("ReservedWordService", {
   toStringOperation: nexus.operation<void, void>({ name: "ToString" }),
@@ -79,7 +69,7 @@ export type ScalarOutput = number;
 /**
  * Input type
  */
-export interface KitchenSinkServiceComplexArgumentComplexResultInlineInput {
+export interface KitchenSinkServiceComplexArgComplexResultInlineInput {
   /**
    * String to count
    */
@@ -89,7 +79,7 @@ export interface KitchenSinkServiceComplexArgumentComplexResultInlineInput {
 /**
  * Output type
  */
-export interface KitchenSinkServiceComplexArgumentComplexResultInlineOutput {
+export interface KitchenSinkServiceComplexArgComplexResultInlineOutput {
   /**
    * Count of characters
    */
@@ -97,7 +87,7 @@ export interface KitchenSinkServiceComplexArgumentComplexResultInlineOutput {
 }
 
 export interface ComplexInput {
-  selfRef?: ComplexInput;
+  selfRef?:       ComplexInput;
   someSharedObj?: SharedObject;
 }
 
@@ -106,7 +96,7 @@ export interface SharedObject {
 }
 
 export interface ComplexOutput {
-  selfRef?: ComplexOutput;
+  selfRef?:       ComplexOutput;
   someSharedObj?: SharedObject;
 }
 
@@ -119,8 +109,8 @@ export interface PurpleStrangeItem {
 }
 
 export interface DateInput {
-  date?: Date;
+  date?:     Date;
   dateTime?: Date;
-  time?: string;
+  time?:     string;
   [property: string]: any;
 }

--- a/src/packages/nexus-rpc-gen-tests/src/multifile.test.ts
+++ b/src/packages/nexus-rpc-gen-tests/src/multifile.test.ts
@@ -8,12 +8,19 @@ import { fileURLToPath } from "node:url";
 const __dirname =
   import.meta.dirname || path.dirname(fileURLToPath(import.meta.url));
 
-const outputDirectory = "packages/nexus-rpc-gen-tests/languages/multifile";
-const absoluteOutputDirectory = path.resolve(
+const tsOutputDirectory = "packages/nexus-rpc-gen-tests/languages/multifile";
+const absoluteTsOutputDirectory = path.resolve(
   __dirname,
   "..",
   "languages",
   "multifile",
+);
+const goOutputDirectory = "packages/nexus-rpc-gen-tests/languages/multifile-go";
+const absoluteGoOutputDirectory = path.resolve(
+  __dirname,
+  "..",
+  "languages",
+  "multifile-go",
 );
 const greetingFile =
   "packages/nexus-rpc-gen-tests/definitions/multifile/greeting.nexusrpc.yaml";
@@ -21,35 +28,37 @@ const echoFile =
   "packages/nexus-rpc-gen-tests/definitions/multifile/echo.nexusrpc.yaml";
 
 before(async () => {
-  await rm(absoluteOutputDirectory, { recursive: true, force: true });
+  await rm(absoluteTsOutputDirectory, { recursive: true, force: true });
+  await rm(absoluteGoOutputDirectory, { recursive: true, force: true });
 });
 
 after(async () => {
-  await rm(absoluteOutputDirectory, { recursive: true, force: true });
+  await rm(absoluteTsOutputDirectory, { recursive: true, force: true });
+  await rm(absoluteGoOutputDirectory, { recursive: true, force: true });
 });
 
-test("Multiple nexusrpc files generate services from all files", async () => {
+test("Multiple nexusrpc files generate services from all files (TypeScript)", async () => {
   // Run gen with both files
   (
     await runRpcGen([
       "--lang",
       "ts",
       "--out-dir",
-      outputDirectory,
+      tsOutputDirectory,
       greetingFile,
       echoFile,
     ])
   ).assertSuccess();
 
   // Read all generated .ts files
-  const files = await readdir(absoluteOutputDirectory);
+  const files = await readdir(absoluteTsOutputDirectory);
   const tsFiles = files.filter((f) => f.endsWith(".ts"));
   assert.ok(tsFiles.length > 0, "Expected at least one generated .ts file");
 
   const generated = (
     await Promise.all(
       tsFiles.map((f) =>
-        readFile(path.resolve(absoluteOutputDirectory, f), "utf8"),
+        readFile(path.resolve(absoluteTsOutputDirectory, f), "utf8"),
       ),
     )
   ).join("\n");
@@ -84,5 +93,54 @@ test("Multiple nexusrpc files generate services from all files", async () => {
   assert.ok(
     generated.includes("echoed"),
     "Generated output should contain echoed field from EchoResponse type",
+  );
+
+  // Should NOT contain filename-derived type exports
+  assert.ok(
+    !generated.match(/\.nexusrpc\.yaml/),
+    "Generated output should not contain filename-derived type references (.nexusrpc.yaml)",
+  );
+});
+
+test("Multiple nexusrpc files generate services from all files (Go)", async () => {
+  // Run gen with both files
+  (
+    await runRpcGen([
+      "--lang",
+      "go",
+      "--out-dir",
+      goOutputDirectory,
+      greetingFile,
+      echoFile,
+    ])
+  ).assertSuccess();
+
+  // Read all generated .go files
+  const files = await readdir(absoluteGoOutputDirectory);
+  const goFiles = files.filter((f) => f.endsWith(".go"));
+  assert.ok(goFiles.length > 0, "Expected at least one generated .go file");
+
+  const generated = (
+    await Promise.all(
+      goFiles.map((f) =>
+        readFile(path.resolve(absoluteGoOutputDirectory, f), "utf8"),
+      ),
+    )
+  ).join("\n");
+
+  // Both services should be present
+  assert.ok(
+    generated.includes("EchoService"),
+    "Generated output should contain EchoService",
+  );
+  assert.ok(
+    generated.includes("GreetingService"),
+    "Generated output should contain GreetingService",
+  );
+
+  // Should NOT contain filename-derived type declarations
+  assert.ok(
+    !generated.match(/NexusrpcYAML|NexusrpcYaml/i),
+    "Generated output should not contain filename-derived types (NexusrpcYAML)",
   );
 });

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -103,6 +103,10 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
 
   packages/nexus-rpc-gen-tests:
     dependencies:
@@ -407,6 +411,9 @@ packages:
 
   '@types/node@24.10.9':
     resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
+
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
   '@types/wordwrap@1.0.3':
     resolution: {integrity: sha512-jx39cOYWJxZxVOZeNHvLVoDLRUFcYtIJaurC6C0qzCovIB3GPDbMDbYvoWi9D1B2PtIE16rElQOFR4Y+8QbUgw==}
@@ -1245,6 +1252,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
 
@@ -1536,6 +1546,10 @@ snapshots:
   '@types/node@24.10.9':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/node@25.5.2':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/wordwrap@1.0.3': {}
 
@@ -2387,6 +2401,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.16.0: {}
+
+  undici-types@7.18.2: {}
 
   unicode-properties@1.4.1:
     dependencies:


### PR DESCRIPTION
When multiple YAML files were passed to the generator, quicktype created top-level type entries from source filenames (e.g., "echo.nexusrpc.yaml") producing invalid output like `export type echo.nexusrpc.yaml = any;` in TypeScript and `type EchoNexusrpcYAML interface{}` in Go.

The root cause: quicktype's JSONSchemaInput.addTypes() only uses the given source name [when there is a single source](https://github.com/glideapps/quicktype/blob/41950205609abd8c18a8e315ea87d8904f625012/packages/quicktype-core/src/input/JSONSchemaInput.ts#L1571-L1578). With multiple sources, it falls back to nameFromURI() which extracts the filename. Setting a `title` on the root schema object ensures quicktype uses that title (ending with /__ALL_TYPES__) instead of the filename, which the existing filters already handle.

Also adds @types/node devDependency to nexus-rpc-gen-core, adds node types to its tsconfig, and regenerates kitchen-sink.ts with updated formatting and shortened type names.