### PR TITLE
Fix build for pnpm v11

### DIFF
--- a/src/pnpm-workspace.yaml
+++ b/src/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - 'packages/*'
+allowBuilds:
+  esbuild: true

--- a/src/pnpm-workspace.yaml
+++ b/src/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'packages/*'
 allowBuilds:
   esbuild: true
+minimumReleaseAge: 1440


### PR DESCRIPTION
# Problem

New security policies in pnpm v11 cause build to fail:
```
➜  src git:(fix-build-pnpm-11) pnpm install && pnpm run build
Scope: all 4 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.2

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

This problem was identified by @chrsmith downstream in [api-go](https://github.com/temporalio/api-go).

# Solution

Added esbuild to allowBuilds.